### PR TITLE
Implement remote user header for SSO support, plus fixes for proxy to root web app context

### DIFF
--- a/src/main/java/com/woonoz/proxy/servlet/HttpRequestHandler.java
+++ b/src/main/java/com/woonoz/proxy/servlet/HttpRequestHandler.java
@@ -25,6 +25,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Enumeration;
 
 import javax.servlet.http.HttpServletRequest;
@@ -38,6 +39,8 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.protocol.BasicHttpContext;
+import org.apache.http.protocol.HttpContext;
 import org.apache.http.util.EntityUtils;
 
 public abstract class HttpRequestHandler {
@@ -75,8 +78,17 @@ public abstract class HttpRequestHandler {
 		ServerHeadersHandler serverHeadersHandler = new ServerHeadersHandler(urlRewriter);
 		HttpRequestBase httpCommand = null;
 		try {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Doing rewrite for uri: " + request.getRequestURL());
+			}
 			final URI targetUri = urlRewriter.rewriteUri(new URI(request.getRequestURL().toString()));
+			if (logger.isDebugEnabled()) {
+				logger.debug("Making request for rewritten uri: " + targetUri);
+			}
 			httpCommand = createHttpCommand(targetUri, clientHeadersHandler);
+			if (logger.isDebugEnabled()) {
+				logger.debug("http client command: " + httpCommand.getRequestLine() + ", headers: " + Arrays.asList(httpCommand.getAllHeaders()));
+			}
 			performHttpRequest(httpCommand, response, serverHeadersHandler);
 		} catch (URISyntaxException e) {
 			handleException(httpCommand, e);
@@ -99,7 +111,7 @@ public abstract class HttpRequestHandler {
 	}
 
 	private void handleException(HttpRequestBase httpCommand, Exception e) {
-		logger.error("Exception handling httpCommand " + httpCommand, e);
+		logger.error("Exception handling httpCommand " + (httpCommand != null ? httpCommand.getURI() : "(missing)") + ": " + e, e);
 		if (httpCommand != null) {
 			httpCommand.abort();
 		}
@@ -138,7 +150,12 @@ public abstract class HttpRequestHandler {
 	}
 
 	private void performHttpRequest(HttpRequestBase requestToServer, HttpServletResponse responseToClient, ServerHeadersHandler serverHeadersHandler) throws IOException, URISyntaxException {
-		HttpResponse responseFromServer = client.execute(requestToServer);
+		HttpContext context = new BasicHttpContext();
+		context.setAttribute(HttpRequestHandler.class.getName(), this);
+		HttpResponse responseFromServer = client.execute(requestToServer, context);
+		if (logger.isDebugEnabled()) {
+			logger.debug("Performed request: " + requestToServer.getRequestLine() + " --> " + responseFromServer.getStatusLine());				
+		}
 		responseToClient.setStatus(responseFromServer.getStatusLine().getStatusCode());
 		copyHeaders(responseFromServer, responseToClient, serverHeadersHandler);
 		HttpEntity entity = responseFromServer.getEntity();

--- a/src/main/java/com/woonoz/proxy/servlet/ProxyServletConfig.java
+++ b/src/main/java/com/woonoz/proxy/servlet/ProxyServletConfig.java
@@ -23,10 +23,12 @@ public class ProxyServletConfig
     private static final int DEFAULT_MAX_CONNECTIONS = 200;
     private static final int DEFAULT_CONNECTION_TIMEOUT = 1000;
     private static final int DEFAULT_SOCKET_TIMEOUT = 5000;
+    private static final String DEFAULT_REMOTE_USER_HEADER = null;
     private final URL targetUrl;
     private final int maxConnections;
     private final int connectionTimeout;
     private final int socketTimeout;
+    private final String remoteUserHeader;
 
     public ProxyServletConfig( ServletConfig config )
             throws MalformedURLException, NumberFormatException
@@ -45,24 +47,32 @@ public class ProxyServletConfig
 
         String soTimeoutParam = config.getInitParameter( "socket-timeout" );
         socketTimeout = soTimeoutParam != null ? Integer.valueOf( soTimeoutParam ) : DEFAULT_SOCKET_TIMEOUT;
+        
+        remoteUserHeader = config.getInitParameter( "remote-user-header" );
     }
 
     public ProxyServletConfig( URL targetUrl )
     {
-        this( targetUrl, DEFAULT_MAX_CONNECTIONS, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_SOCKET_TIMEOUT );
+        this( targetUrl, DEFAULT_MAX_CONNECTIONS, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_SOCKET_TIMEOUT, DEFAULT_REMOTE_USER_HEADER );
     }
 
     public ProxyServletConfig( URL targetUrl, int maxConnections )
     {
-        this( targetUrl, maxConnections, DEFAULT_MAX_CONNECTIONS, DEFAULT_SOCKET_TIMEOUT );
+        this( targetUrl, maxConnections, DEFAULT_MAX_CONNECTIONS, DEFAULT_SOCKET_TIMEOUT, DEFAULT_REMOTE_USER_HEADER );
     }
 
     public ProxyServletConfig( URL targetUrl, int maxConnections, int connectionTimeout, int socketTimeout )
+    {
+        this( targetUrl, maxConnections, connectionTimeout, socketTimeout, DEFAULT_REMOTE_USER_HEADER );
+    }
+    
+    public ProxyServletConfig( URL targetUrl, int maxConnections, int connectionTimeout, int socketTimeout, String remoteUserHeader )
     {
         this.targetUrl = targetUrl;
         this.maxConnections = maxConnections;
         this.connectionTimeout = connectionTimeout;
         this.socketTimeout = socketTimeout;
+        this.remoteUserHeader = remoteUserHeader;
     }
 
     public URL getTargetUrl()
@@ -85,4 +95,8 @@ public class ProxyServletConfig
         return socketTimeout;
     }
 
+    public String getRemoteUserHeader() 
+    {
+        return remoteUserHeader;
+    }
 }

--- a/src/main/java/com/woonoz/proxy/servlet/UrlRewriterImpl.java
+++ b/src/main/java/com/woonoz/proxy/servlet/UrlRewriterImpl.java
@@ -96,7 +96,7 @@ public class UrlRewriterImpl implements UrlRewriter {
 	
 	private String rewritePathIfNeeded(String requestedPath) {
 		String servletURI = servletRequest.getContextPath() + servletRequest.getServletPath();
-		if (requestIsSubpathOfServlet(requestedPath)) {
+		if (targetServer.getPath().length() != 0 && requestIsSubpathOfServlet(requestedPath)) {
 			return appendPathFragments(targetServer.getPath(), requestedPath.substring(servletURI.length()));
 		} else {
 			return requestedPath;
@@ -108,6 +108,9 @@ public class UrlRewriterImpl implements UrlRewriter {
 	}
 	
 	private static String removeTrailingSlashes(final String text) {
+		if (text.length() == 0) {
+			return text;
+		}
 		final CharacterIterator it = new StringCharacterIterator(text);
 		Character c = it.last();
 		while (c.equals('/')) {
@@ -117,6 +120,9 @@ public class UrlRewriterImpl implements UrlRewriter {
 	}
 
 	private static String removeLeadingSlashes(final String text) {
+		if (text.length() == 0) {
+			return text;
+		}
 		final CharacterIterator it = new StringCharacterIterator(text);
 		Character c = it.first();
 		while (c.equals('/')) {

--- a/src/test/java/com/woonoz/proxy/servlet/UrlRewriterTest.java
+++ b/src/test/java/com/woonoz/proxy/servlet/UrlRewriterTest.java
@@ -101,6 +101,9 @@ public class UrlRewriterTest {
 		return new URL("http://localhost:8180/services/");
 	}
 
+	private URL buildRedirectUrlRoot() throws MalformedURLException {
+		return new URL("http://localhost:8180");
+	}
 
 	private URL buildRedirectUrlWithoutPort() throws MalformedURLException {
 		return new URL("http://localhost/services/");
@@ -215,6 +218,17 @@ public class UrlRewriterTest {
 		URI requestUri = new URI("https://online.woonoz-pro.com/wol-wnz-pro-2/com.woonoz.gwt.woonoz.Woonoz/proxy/gwt/AuthenticationServiceService");
 		URI expectedUri = new URI("http://localhost:8180/services-wnz-pro-2/gwt/AuthenticationServiceService");
 		Assert.assertEquals(expectedUri, rewriter.rewriteUri(requestUri));
+		EasyMock.verify(request);
+	}
+
+	@Test
+	public void testRewriteUriRedirectToRoot() throws MalformedURLException, URISyntaxException {
+		HttpServletRequest request = buildGoogleDotComServletRequest();
+		URL redirectUrl = buildRedirectUrlRoot();
+		UrlRewriter rewriter = new UrlRewriterImpl(request, redirectUrl);
+		URI uri = new URI("http://www.google.com/proxy/doc/from/root/index.html");
+		URI expectedUri = new URI("http://localhost:8180/proxy/doc/from/root/index.html");
+		Assert.assertEquals(expectedUri, rewriter.rewriteUri(uri));
 		EasyMock.verify(request);
 	}
 


### PR DESCRIPTION
Changes in this request:

Add configuration option for remote-user-header init param, which initiates interceptor that governs sending HttpServletRequest.getRemoteUser().  Uses http client HttpContext to allow context access  to client interceptor for the current request (via the HttpRequestHandler instance).  Fixes for proxy to a target that has no URI--to root web app use-case (e.g. proxy to http://some.host.com), plus a unit test for this fix.  Implement logging/tracing of outbound requests.

(original pull request):

Hi, I've added a new feature to your proxy which will allow an authenticated application to also proxy to back-end origin servers and pass the current http "remote user" to those servers. This is similar to what is done with a product like CA Siteminder, which uses HTTP header injection while proxying such that the receiving application can be notified of a pre-authenticated user.

This has implications for those using spring security, for example. A back end application using spring security can accept requests with the "siteminder" scheme, with little or not application code changes. 
