### PR TITLE
Update logging usage for debug() statements to use slf4j zero-impact argument mechanism

### DIFF
--- a/src/main/java/com/woonoz/proxy/servlet/HttpRequestHandler.java
+++ b/src/main/java/com/woonoz/proxy/servlet/HttpRequestHandler.java
@@ -78,11 +78,11 @@ public abstract class HttpRequestHandler {
 		ServerHeadersHandler serverHeadersHandler = new ServerHeadersHandler(urlRewriter);
 		HttpRequestBase httpCommand = null;
 		try {
-			logger.debug("Doing rewrite for uri: " + request.getRequestURL());
+			logger.debug("Doing rewrite for uri: {}", request.getRequestURL());
 			final URI targetUri = urlRewriter.rewriteUri(new URI(request.getRequestURL().toString()));
-			logger.debug("Making request for rewritten uri: " + targetUri);
+			logger.debug("Making request for rewritten uri: {}", targetUri);
 			httpCommand = createHttpCommand(targetUri, clientHeadersHandler);
-			logger.debug("http client command: " + httpCommand.getRequestLine() + ", headers: " + Arrays.asList(httpCommand.getAllHeaders()));
+			logger.debug("Http client command: {}, headers: {}", httpCommand.getRequestLine(), Arrays.asList(httpCommand.getAllHeaders()));
 			performHttpRequest(httpCommand, response, serverHeadersHandler);
 		} catch (URISyntaxException e) {
 			handleException(httpCommand, e);
@@ -105,7 +105,7 @@ public abstract class HttpRequestHandler {
 	}
 
 	private void handleException(HttpRequestBase httpCommand, Exception e) {
-		logger.error("Exception handling httpCommand " + (httpCommand != null ? httpCommand.getURI() : "(missing)") + ": " + e, e);
+		logger.error("Exception handling httpCommand: {}", (httpCommand != null ? httpCommand.getURI() : "(missing)"), e);
 		if (httpCommand != null) {
 			httpCommand.abort();
 		}
@@ -147,7 +147,7 @@ public abstract class HttpRequestHandler {
 		HttpContext context = new BasicHttpContext();
 		context.setAttribute(HttpRequestHandler.class.getName(), this);
 		HttpResponse responseFromServer = client.execute(requestToServer, context);
-		logger.debug("Performed request: " + requestToServer.getRequestLine() + " --> " + responseFromServer.getStatusLine());				
+		logger.debug("Performed request: {} --> {}", requestToServer.getRequestLine(), responseFromServer.getStatusLine());				
 		responseToClient.setStatus(responseFromServer.getStatusLine().getStatusCode());
 		copyHeaders(responseFromServer, responseToClient, serverHeadersHandler);
 		HttpEntity entity = responseFromServer.getEntity();


### PR DESCRIPTION
Using log.debug("Some {} log {} message", arg1, arg2) construct, the log.isDebugEnabled() check can be avoided, and any potential string concatenation can be avoided if log.debug() is not enabled for the logger.  Change trace statements appropriately.
