### PR TITLE
Force ActiveSync version by rewriting MS-ASProtocolVersions response hea...

### DIFF
--- a/core/src/main/java/com/woonoz/proxy/servlet/base/ServerHeadersHandler.java
+++ b/core/src/main/java/com/woonoz/proxy/servlet/base/ServerHeadersHandler.java
@@ -22,7 +22,10 @@ package com.woonoz.proxy.servlet.base;
 
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.woonoz.proxy.servlet.http.header.AbstractHeadersHandler;
 import com.woonoz.proxy.servlet.http.header.HeadersFilter;
 import com.woonoz.proxy.servlet.url.UrlRewriter;
@@ -30,7 +33,16 @@ import com.woonoz.proxy.servlet.url.UrlRewriter;
 public class ServerHeadersHandler extends AbstractHeadersHandler {
 
 	public ServerHeadersHandler(UrlRewriter urlRewriter) {
-		super(urlRewriter, RequiredHeaders.values());
+		super(urlRewriter, ImmutableList.<HeadersFilter>of());
+	}
+	
+	public ServerHeadersHandler(UrlRewriter urlRewriter, Iterable<HeadersFilter> filters) {
+		super(urlRewriter, joinFilters(filters));
+	}
+	
+	private static Iterable<HeadersFilter> joinFilters(final Iterable<HeadersFilter> filters) {
+		Iterable<HeadersFilter> requiredFilters = Arrays.<HeadersFilter>asList(RequiredHeaders.values());
+		return Iterables.concat(requiredFilters, filters);
 	}
 	
 	private enum RequiredHeaders implements HeadersFilter {

--- a/exchange-active-sync-proxy/src/main/java/com/woonoz/proxy/activesync/GuiceServletConfig.java
+++ b/exchange-active-sync-proxy/src/main/java/com/woonoz/proxy/activesync/GuiceServletConfig.java
@@ -18,19 +18,21 @@ import com.woonoz.proxy.servlet.http.header.HeadersFilter;
 public class GuiceServletConfig extends GuiceServletContextListener {
 
 	private URL targetUrl;
-	private List<Class<? extends HeadersFilter>> filters;
+	private List<Class<? extends HeadersFilter>> clientFilters;
+	private List<Class<? extends HeadersFilter>> serverFilters;
 	private ProxyServletConfig proxyServletConfig;
 
 	public GuiceServletConfig() throws MalformedURLException {
 		targetUrl = new URL("http://10.69.0.62/");
 		proxyServletConfig = new ProxyServletConfig(targetUrl, 10, 1000000, 1000000);
-		filters = Arrays.<Class<? extends HeadersFilter>>asList(EAS12Point1.class);
+		clientFilters = Arrays.<Class<? extends HeadersFilter>>asList(EAS12Point1.class);
+		serverFilters = Arrays.<Class<? extends HeadersFilter>>asList(ServerAS12Point1.class);
 	}
 	
 	@Override
 	protected Injector getInjector() {
 		return Guice.createInjector(
-				new SimpleGuiceProxyServletModule(proxyServletConfig, filters),
+				new SimpleGuiceProxyServletModule(proxyServletConfig, clientFilters, serverFilters),
 				new ServletModule() {
 			@Override
 			protected void configureServlets() {

--- a/exchange-active-sync-proxy/src/main/java/com/woonoz/proxy/activesync/ServerAS12Point1.java
+++ b/exchange-active-sync-proxy/src/main/java/com/woonoz/proxy/activesync/ServerAS12Point1.java
@@ -1,0 +1,21 @@
+package com.woonoz.proxy.activesync;
+
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+
+import com.woonoz.proxy.servlet.http.header.HeadersFilter;
+import com.woonoz.proxy.servlet.url.UrlRewriter;
+
+public class ServerAS12Point1 implements HeadersFilter {
+
+	@Override
+	public String getHeader() {
+		return "MS-ASProtocolVersions";
+	}
+	
+	@Override
+	public String handleValue(String headerValue, UrlRewriter urlRewriter)
+			throws URISyntaxException, MalformedURLException {
+		return "12.1";
+	}
+}

--- a/guice-extension-loader/src/main/java/com/woonoz/proxy/servlet/GuiceHttpRequestHandlerFactory.java
+++ b/guice-extension-loader/src/main/java/com/woonoz/proxy/servlet/GuiceHttpRequestHandlerFactory.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 
 import com.google.inject.Inject;
+import com.google.inject.name.Named;
 import com.woonoz.proxy.servlet.base.ClientHeadersHandler;
 import com.woonoz.proxy.servlet.base.HttpEntityEnclosingHeadersHandler;
 import com.woonoz.proxy.servlet.base.HttpRequestHandlerImpl;
@@ -18,18 +19,23 @@ import com.woonoz.proxy.servlet.url.UrlRewriter;
 public class GuiceHttpRequestHandlerFactory implements HttpRequestHandler.Factory {
 
 	private final Set<HeadersFilter> clientFilters;
+	private final Set<HeadersFilter> serverFilters;
 
 	@Inject
-	private GuiceHttpRequestHandlerFactory(Set<HeadersFilter> clientFilters) {
+	private GuiceHttpRequestHandlerFactory(
+			@Named("clientFilters")Set<HeadersFilter> clientFilters,
+			@Named("serverFilters")Set<HeadersFilter> serverFilters) {
 		this.clientFilters = clientFilters;
+		this.serverFilters = serverFilters;
 	}
 
 	@Override
 	public HttpRequestHandler create(HttpServletRequest request, URL targetServer) {
 		UrlRewriter urlRewriter = new UrlRewriterImpl(request, targetServer);
 		ClientHeadersHandler clientHeadersHandler = new ClientHeadersHandler(urlRewriter, clientFilters);
+		ServerHeadersHandler serverHeadersHandler = new ServerHeadersHandler(urlRewriter, serverFilters);
 		HttpEntityEnclosingHeadersHandler httpEntityEnclosingHeadersHandler = new HttpEntityEnclosingHeadersHandler(urlRewriter, clientFilters);
 		return new HttpRequestHandlerImpl(urlRewriter, clientHeadersHandler,
-				httpEntityEnclosingHeadersHandler, new ServerHeadersHandler(urlRewriter));
+				httpEntityEnclosingHeadersHandler, serverHeadersHandler);
 	}
 }


### PR DESCRIPTION
Forcing ActiveSync communication to a version need to rewrite server "MS-ASProtocolVersions" headers. The header value is the list of server's compatibles ActiveSync version.
